### PR TITLE
Update composer.json to require a PHP5-compatible version of Elastica

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   ],
   "require": {
     "php": ">=5.3.0",
-    "ruflin/Elastica": "dev-master"
+    "ruflin/Elastica": "5.1.0"
   },
   "repositories": [
     {


### PR DESCRIPTION
Elastica recently [dropped PHP 5 support](https://github.com/ruflin/Elastica/pull/1356), breaking our dependency. Requiring last known PHP5-supported release of Elastica (5.1) should fix this.